### PR TITLE
proper phpdoc param annotation #38

### DIFF
--- a/tests/AppBundle/EdgeToEdge/UserLoginTest.php
+++ b/tests/AppBundle/EdgeToEdge/UserLoginTest.php
@@ -75,6 +75,7 @@ class UserLoginTest extends WebTestCase
     }
 
     /**
+     * @param string $url
      * @dataProvider urlProvider
      */
     public function testUserLoginFrontendWithBadCredentialsIsRedirected($url)
@@ -90,9 +91,10 @@ class UserLoginTest extends WebTestCase
         $this->assertStatusCode(302, $client);
     }
     /**
+     * @param string $url
      * @dataProvider urlProvider
      */
-    public function testUserLoginFrontendDisabledAccountisRedirected($url)
+    public function testUserLoginFrontendDisabledAccountIsRedirected($url)
     {
         $this->loadUserFixtures();
 
@@ -106,6 +108,7 @@ class UserLoginTest extends WebTestCase
     }
 
     /**
+     * @param string $url
      * @dataProvider urlProvider
      */
     public function testUserLoginFrontendAdminUserHasAccess($url)


### PR DESCRIPTION
  and fix another test method name

phpstorm inspection gives warnings about changing static Liip call to call on instantiated object

`static::makeClient()` => `$this->makeClient()`

and vice versa

`this->assert....` => `static::assert....`   