### PR TITLE
PR for upload_max_filesize from 2048 KiB

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-    "directory": "bower_components",
-    "timeout": 120000
-}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ sudo service apache2 reload
 curl -sS https://getcomposer.org/installer | php
 php composer.phar install
 ```
+### Install assets
+
+```
+nvm install v7.1.0
+nvm use v7.1.0
+
+npm install
+yarn install
+```
+
 ### Set up parameters
 You have to set database and mailer credentials in your
 `app/config/parameters.yml`.
@@ -114,34 +124,18 @@ Call in terminal:
 php app/check.php
 ```
 
-### Install assets
-
+### run webpack encore
+dev mode
+enables dev options like sourcemaps
 ```
-nvm install v7.1.0
-nvm use v7.1.0
-
-npm install
-./node_modules/.bin/bower install
+node_modules/.bin/encore dev
 ```
 
-### run webpack dev server
-
-This one launches the webpack dev server which serves js and css assets in dev environment.
-It also reloads web page on asset change.
-
+production switch
 ```
-node_modules/.bin/webpack-dev-server
-
-
+node_modules/.bin/encore production
 ```
 
-### want to create assets for non dev environment?
-
-```
-node_modules/.bin/webpack
-
-
-```
 ### Open in browser:
 
 ```

--- a/src/AppBundle/Entity/WayPoint.php
+++ b/src/AppBundle/Entity/WayPoint.php
@@ -26,6 +26,8 @@ class WayPoint
      *
      * @Vich\UploadableField(mapping="way_point_image", fileNameProperty="imageName")
      *
+     * @Assert\File(maxSize = "2048k")
+     *
      * @var File $imageFile
      */
     private $imageFile;


### PR DESCRIPTION
Fixes #46
No separate branch. The 2 trivial commits should be easily fast forward merged.
The maximum filesize for uploaded files was not increased since this can only be changed by an op.
Also the maxSize assertion is hard coded into the waypoint entity . So if `upload_max_filesize` in php.ini ever increases the assertion needs to be updated as well.

Also added some updates to README.md concerning new package management with yarn, webpack encore and removed references to bower.